### PR TITLE
feat: xterm.js terminal + bunshin session/execute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       in
       {
         packages.chrome-devtools-mcp = pkgs.writeShellScriptBin "chrome-devtools-mcp" ''
-          exec ${pkgs.pnpm}/bin/pnpm dlx chrome-devtools-mcp@latest -e ${pkgs.google-chrome}/bin/google-chrome-stable "$@"
+          exec ${pkgs.nodejs_24}/bin/npx -y chrome-devtools-mcp --isolated -e ${pkgs.google-chrome}/bin/google-chrome-stable "$@"
         '';
 
         devShells.default = pkgs.mkShell {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -880,6 +881,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -896,6 +898,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -912,6 +915,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -928,6 +932,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -944,6 +949,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -957,7 +963,7 @@
       "version": "4.20260317.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
       "integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1006,6 +1012,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1030,6 +1037,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1046,6 +1054,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,6 +1071,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,6 +1088,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1094,6 +1105,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1110,6 +1122,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,6 +1139,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1142,6 +1156,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,6 +1173,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,6 +1190,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,6 +1207,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1206,6 +1224,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,6 +1241,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,6 +1258,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,6 +1275,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1270,6 +1292,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1286,6 +1309,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,6 +1326,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,6 +1343,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1334,6 +1360,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1350,6 +1377,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1366,6 +1394,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,6 +1411,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,6 +1428,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,6 +1445,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1430,6 +1462,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1588,6 +1621,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1610,6 +1644,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1632,6 +1667,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1648,6 +1684,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1664,6 +1701,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1680,6 +1718,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1696,6 +1735,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1712,6 +1752,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1728,6 +1769,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1744,6 +1786,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1760,6 +1803,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1776,6 +1820,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1792,6 +1837,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1814,6 +1860,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1836,6 +1883,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1858,6 +1906,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1880,6 +1929,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1902,6 +1952,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1924,6 +1975,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1946,6 +1998,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1968,6 +2021,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1987,6 +2041,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2006,6 +2061,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2025,6 +2081,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2247,52 +2304,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@nuxt/kit": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.1.tgz",
-      "integrity": "sha512-QORZRjcuTKgo++XP1Pc2c2gqwRydkaExrIRfRI9vFsPA3AzuHVn5Gfmbv1ic8y34e78mr5DMBvJlelUaeOuajg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "c12": "^3.3.3",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
-        "jiti": "^2.6.1",
-        "klona": "^2.0.6",
-        "knitwork": "^1.3.0",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^3.0.0",
-        "scule": "^1.3.0",
-        "semver": "^7.7.4",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unctx": "^2.5.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
-    "node_modules/@nuxt/kit/node_modules/rc9": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.0.tgz",
-      "integrity": "sha512-MGOue0VqscKWQ104udASX/3GYDcKyPI4j4F8gu/jHHzglpmy9a/anZK3PNe8ug6aZFl+9GxLtdhe3kVZuMaQbA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.5"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -4255,6 +4266,7 @@
       "version": "14.1.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5180,6 +5192,22 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@zhead/schema": {
       "version": "0.8.5",
       "dev": true,
@@ -5486,6 +5514,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5971,6 +6000,7 @@
       "version": "3.33.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6355,6 +6385,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7454,6 +7485,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7775,6 +7807,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8480,6 +8513,7 @@
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -8496,6 +8530,7 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/markdown-it": "^14.1.2",
         "markdown-it": "^14.1.0"
@@ -9293,6 +9328,7 @@
       "integrity": "sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
@@ -9609,6 +9645,7 @@
       "integrity": "sha512-2w7Xn3CbS/zwzSY82S5WLemrRu3CT57uF7Lx8llrE/2bul6iMTcJE4Rbls7GDNbLn3ttATI68PfOz2Pt3KZ2cQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.115.0"
       },
@@ -9814,6 +9851,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -9889,6 +9927,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10237,6 +10276,7 @@
       "version": "4.53.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12161,6 +12201,7 @@
       "version": "3.2.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",
@@ -12553,10 +12594,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/test": {
-      "resolved": "slidev/test",
-      "link": true
-    },
     "node_modules/theme-vitesse": {
       "version": "0.1.14",
       "dev": true,
@@ -12651,7 +12688,7 @@
     },
     "node_modules/tslib": {
       "version": "2.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/twoslash": {
@@ -12704,6 +12741,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12833,6 +12871,7 @@
       "version": "2.0.0-rc.24",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -13247,6 +13286,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13611,6 +13651,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",
@@ -13817,6 +13858,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -13837,6 +13879,7 @@
       "integrity": "sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.16.0",
@@ -13889,6 +13932,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13905,6 +13949,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13921,6 +13966,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13937,6 +13983,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13953,6 +14000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -14000,6 +14048,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -14270,7 +14319,11 @@
       "version": "0.0.1"
     },
     "slidev/my-strongest-presentation-slides": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dependencies": {
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0"
+      }
     },
     "slidev/playwright-mcp-best-effort": {
       "version": "0.0.1"
@@ -14288,7 +14341,8 @@
       "version": "0.0.1"
     },
     "slidev/test": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "extraneous": true
     },
     "slidev/upgrade-to-rrv7": {
       "version": "0.0.1"

--- a/slidev/my-strongest-presentation-slides/components/Terminal.vue
+++ b/slidev/my-strongest-presentation-slides/components/Terminal.vue
@@ -4,13 +4,9 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 
-const props = withDefaults(defineProps<{
-  rows?: number
-  fontSize?: number
-}>(), {
-  rows: 8,
-  fontSize: 14,
-})
+const props = defineProps<{
+  fontSize: number
+}>()
 
 const containerRef = ref<HTMLDivElement>()
 let xterm: XTerm | null = null
@@ -24,7 +20,7 @@ onMounted(() => {
   xterm = new XTerm({
     convertEol: true,
     fontSize: props.fontSize,
-    rows: props.rows,
+    rows: 16,
     theme: {
       background: '#121212',
       foreground: '#D4D4D4',
@@ -82,6 +78,7 @@ defineExpose({ write, writeln, clear })
   border: 1px solid rgba(78, 201, 176, 0.15);
   border-radius: 8px;
   overflow: hidden;
+  pointer-events: none;
   box-sizing: border-box;
   background: #121212;
   padding: 4px;

--- a/slidev/my-strongest-presentation-slides/components/Terminal.vue
+++ b/slidev/my-strongest-presentation-slides/components/Terminal.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { Terminal as XTerm } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+
+const props = withDefaults(defineProps<{
+  rows?: number
+  fontSize?: number
+}>(), {
+  rows: 8,
+  fontSize: 14,
+})
+
+const containerRef = ref<HTMLDivElement>()
+let xterm: XTerm | null = null
+let fitAddon: FitAddon | null = null
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  const el = containerRef.value
+  if (!el) return
+
+  xterm = new XTerm({
+    convertEol: true,
+    fontSize: props.fontSize,
+    rows: props.rows,
+    theme: {
+      background: '#121212',
+      foreground: '#D4D4D4',
+      cursor: '#4ec9b0',
+      selectionBackground: 'rgba(78, 201, 176, 0.3)',
+    },
+    scrollback: 1000,
+    disableStdin: true,
+  })
+
+  fitAddon = new FitAddon()
+  xterm.loadAddon(fitAddon)
+  xterm.open(el)
+  fitAddon.fit()
+
+  resizeObserver = new ResizeObserver(() => {
+    fitAddon?.fit()
+  })
+  resizeObserver.observe(el)
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+  xterm?.dispose()
+  xterm = null
+  fitAddon = null
+  resizeObserver = null
+})
+
+function write(data: string): void {
+  xterm?.write(data)
+}
+
+function writeln(data: string): void {
+  xterm?.writeln(data)
+}
+
+function clear(): void {
+  xterm?.clear()
+}
+
+defineExpose({ write, writeln, clear })
+</script>
+
+<template>
+  <div
+    ref="containerRef"
+    class="terminal-container"
+  />
+</template>
+
+<style scoped>
+.terminal-container {
+  width: 100%;
+  border: 1px solid rgba(78, 201, 176, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+  box-sizing: border-box;
+  background: #121212;
+  padding: 4px;
+}
+</style>

--- a/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
+++ b/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
@@ -5,14 +5,14 @@ export type SseEvent =
   | { type: 'stderr'; data: string }
   | { type: 'complete'; exitCode: number }
 
-export function useBunshinExecute() {
+export const useBunshinExecute = () => {
   const isExecuting = ref(false)
 
-  async function execute(
+  const execute = async (
     command: string,
     onEvent: (event: SseEvent) => void,
     signal?: AbortSignal,
-  ): Promise<void> {
+  ): Promise<void> => {
     isExecuting.value = true
     try {
       const res = await fetch('/bunshin/execute', {

--- a/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
+++ b/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
@@ -1,9 +1,15 @@
 import { ref } from 'vue'
 
+export const SseEventType = {
+  STDOUT: 'stdout',
+  STDERR: 'stderr',
+  COMPLETE: 'complete',
+} as const
+
 export type SseEvent =
-  | { type: 'stdout'; data: string }
-  | { type: 'stderr'; data: string }
-  | { type: 'complete'; exitCode: number }
+  | { type: typeof SseEventType.STDOUT; data: string }
+  | { type: typeof SseEventType.STDERR; data: string }
+  | { type: typeof SseEventType.COMPLETE; exitCode: number }
 
 export const useBunshinExecute = () => {
   const isExecuting = ref(false)

--- a/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
+++ b/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
@@ -22,7 +22,11 @@ export function useBunshinExecute() {
         body: JSON.stringify({ command }),
         signal,
       })
-      if (!res.ok) throw new Error(`Failed to execute: ${res.status}`)
+      if (!res.ok) {
+        const body = await res.json().catch(() => null)
+        const message = body?.error ?? `Failed to execute: ${res.status}`
+        throw new Error(message)
+      }
       if (!res.body) throw new Error('No response body')
 
       const reader = res.body.getReader()

--- a/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
+++ b/slidev/my-strongest-presentation-slides/composables/useBunshinExecute.ts
@@ -1,0 +1,54 @@
+import { ref } from 'vue'
+
+export type SseEvent =
+  | { type: 'stdout'; data: string }
+  | { type: 'stderr'; data: string }
+  | { type: 'complete'; exitCode: number }
+
+export function useBunshinExecute() {
+  const isExecuting = ref(false)
+
+  async function execute(
+    command: string,
+    onEvent: (event: SseEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    isExecuting.value = true
+    try {
+      const res = await fetch('/bunshin/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ command }),
+        signal,
+      })
+      if (!res.ok) throw new Error(`Failed to execute: ${res.status}`)
+      if (!res.body) throw new Error('No response body')
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      const chunks: string[] = []
+
+      for (;;) {
+        const { done, value } = await reader.read()
+        chunks.push(done ? decoder.decode() : decoder.decode(value, { stream: true }))
+
+        const lines = chunks.join('').split('\n')
+        chunks.length = 0
+        if (!done) chunks.push(lines.pop()!)
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const event = JSON.parse(line.slice(6)) as SseEvent
+          onEvent(event)
+        }
+
+        if (done) break
+      }
+    } finally {
+      isExecuting.value = false
+    }
+  }
+
+  return { execute, isExecuting }
+}

--- a/slidev/my-strongest-presentation-slides/composables/useBunshinSession.ts
+++ b/slidev/my-strongest-presentation-slides/composables/useBunshinSession.ts
@@ -1,0 +1,63 @@
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const sessionReady = ref(false)
+const sessionError = ref<string | null>(null)
+let refCount = 0
+let creating = false
+
+const MAX_DELAY_MS = 8000
+
+async function tryCreateSession(delay: number): Promise<void> {
+  try {
+    const res = await fetch('/bunshin/session', {
+      method: 'POST',
+      credentials: 'include',
+    })
+    if (!res.ok) throw new Error(`Failed to create session: ${res.status}`)
+    sessionReady.value = true
+    sessionError.value = null
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    sessionError.value = message
+    console.error('Failed to create bunshin session', err)
+    const nextDelay = Math.min(delay * 2, MAX_DELAY_MS)
+    setTimeout(() => {
+      if (refCount > 0 && !sessionReady.value) {
+        void tryCreateSession(nextDelay)
+      }
+    }, delay)
+  }
+}
+
+function destroySession(): void {
+  void fetch('/bunshin/session', {
+    method: 'DELETE',
+    credentials: 'include',
+    keepalive: true,
+  }).catch((err: unknown) => {
+    console.error('Failed to delete bunshin session', err)
+  })
+  sessionReady.value = false
+  sessionError.value = null
+  creating = false
+}
+
+export function useBunshinSession() {
+  onMounted(() => {
+    refCount++
+    if (!creating && !sessionReady.value) {
+      creating = true
+      void tryCreateSession(1000)
+    }
+  })
+
+  onUnmounted(() => {
+    refCount--
+    if (refCount <= 0) {
+      refCount = 0
+      destroySession()
+    }
+  })
+
+  return { sessionReady, sessionError }
+}

--- a/slidev/my-strongest-presentation-slides/composables/useBunshinSession.ts
+++ b/slidev/my-strongest-presentation-slides/composables/useBunshinSession.ts
@@ -7,7 +7,7 @@ let creating = false
 
 const MAX_DELAY_MS = 8000
 
-async function tryCreateSession(delay: number): Promise<void> {
+const tryCreateSession = async (delay: number): Promise<void> => {
   try {
     const res = await fetch('/bunshin/session', {
       method: 'POST',
@@ -29,7 +29,7 @@ async function tryCreateSession(delay: number): Promise<void> {
   }
 }
 
-function destroySession(): void {
+const destroySession = (): void => {
   void fetch('/bunshin/session', {
     method: 'DELETE',
     credentials: 'include',
@@ -42,7 +42,7 @@ function destroySession(): void {
   creating = false
 }
 
-export function useBunshinSession() {
+export const useBunshinSession = () => {
   onMounted(() => {
     refCount++
     if (!creating && !sessionReady.value) {

--- a/slidev/my-strongest-presentation-slides/package.json
+++ b/slidev/my-strongest-presentation-slides/package.json
@@ -4,6 +4,10 @@
   "version": "0.0.1",
   "private": true,
   "author": "ogadra",
+  "dependencies": {
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0"
+  },
   "scripts": {
     "build": "npm run build:slidev && npm run build:copy",
     "build:copy": "cp -r ./slides-export ../../dist/my-strongest-presentation-slides",

--- a/slidev/my-strongest-presentation-slides/vite.config.ts
+++ b/slidev/my-strongest-presentation-slides/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    proxy: {
+      '/bunshin': {
+        target: 'http://localhost:80',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/bunshin/, '/api'),
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Add `Terminal.vue` (xterm.js wrapper with dark theme, ResizeObserver, defineExpose)
- Add `useBunshinSession` composable (singleton session with ref counting, retry)
- Add `useBunshinExecute` composable (SSE stream command execution)
- Add `@xterm/xterm` and `@xterm/addon-fit` dependencies

## Stack
1/3: This PR → xterm.js + session/execute infrastructure
2/3: Monaco input + DemoTerminal integration
3/3: slides.md demo slide replacement

## Test plan
- [ ] `npm run dev` starts without errors
- [ ] Terminal.vue renders xterm instance when mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)