### PR TITLE
feat: replace demo slides with interactive DemoTerminal

### DIFF
--- a/slidev/my-strongest-presentation-slides/components/DemoTerminal.vue
+++ b/slidev/my-strongest-presentation-slides/components/DemoTerminal.vue
@@ -127,17 +127,6 @@ async function handleExecute() {
   min-width: 0;
 }
 
-.connecting {
-  text-align: center;
-  color: #888;
-  padding: 2rem 0;
-  font-size: 1.1rem;
-}
-
-.connecting .error {
-  color: #ff6b6b;
-}
-
 .input-row {
   display: flex;
   gap: 0.5rem;
@@ -189,10 +178,4 @@ async function handleExecute() {
   font-weight: bold;
 }
 
-.caption {
-  text-align: center;
-  margin-top: 0.4rem;
-  color: #ff6b6b;
-  font-size: 1.1rem !important;
-}
 </style>

--- a/slidev/my-strongest-presentation-slides/components/Terminal.vue
+++ b/slidev/my-strongest-presentation-slides/components/Terminal.vue
@@ -78,7 +78,7 @@ defineExpose({ write, writeln, clear })
   border: 1px solid rgba(78, 201, 176, 0.15);
   border-radius: 8px;
   overflow: hidden;
-  pointer-events: none;
+  user-select: none;
   box-sizing: border-box;
   background: #121212;
   padding: 4px;

--- a/slidev/my-strongest-presentation-slides/slides.md
+++ b/slidev/my-strongest-presentation-slides/slides.md
@@ -69,10 +69,7 @@ canvasWidth: 960
 
 ## デモ
 
-<DemoTerminal
-  suggestedCommand='echo "hello from $(hostname)"'
-  caption="← 全員違う hostname になるはず"
-/>
+<DemoTerminal suggestedCommand='echo "hello from $(hostname)"' />
 
 ---
 
@@ -196,8 +193,8 @@ R --> B : レスポンス
 ## デモ
 
 <div style="display: flex; gap: 1rem;">
-  <DemoTerminal suggestedCommand="pwd" :rows="4" style="flex: 1;" />
-  <DemoTerminal suggestedCommand="cd /tmp" :rows="4" style="flex: 1;" />
+  <DemoTerminal suggestedCommand="pwd" style="flex: 1;" />
+  <DemoTerminal suggestedCommand="cd /tmp" style="flex: 1;" />
 </div>
 
 <p style="text-align: center; margin-top: 0.5rem; color: #ff6b6b; font-size: 1.1rem !important;">← cd した結果が引き継がれているはず</p>

--- a/slidev/my-strongest-presentation-slides/slides.md
+++ b/slidev/my-strongest-presentation-slides/slides.md
@@ -69,26 +69,10 @@ canvasWidth: 960
 
 ## デモ
 
-<div style="height: 20px" />
-
-<div style="display: flex; justify-content: center; align-items: center; gap: 3rem;">
-  <div style="text-align: center;">
-  </div>
-  <div style="text-align: left;">
-    <p style="font-size: 1.2rem !important; color: #aaa;">以下のコマンドを入力してみてください</p>
-    <div style="margin-top: 1rem;">
-
-```bash
-echo "hello from $(hostname)"
-```
-
-  </div>
-  </div>
-</div>
-
-<div style="margin-top: 1.5rem; text-align: center;">
-  <p style="font-size: 1.1rem !important; color: #ff6b6b;">← 全員違う hostname になるはず</p>
-</div>
+<DemoTerminal
+  suggestedCommand='echo "hello from $(hostname)"'
+  caption="← 全員違う hostname になるはず"
+/>
 
 ---
 
@@ -211,28 +195,12 @@ R --> B : レスポンス
 
 ## デモ
 
-<div style="height: 20px" />
-
-<div style="display: flex; justify-content: center; align-items: center; gap: 3rem;">
-  <div style="text-align: left;">
-    <p style="font-size: 1.2rem !important; color: #aaa;">以下のコマンドを順番に入力してみてください</p>
-    <div style="margin-top: 1rem;">
-
-```bash
-cd /tmp
-```
-
-```bash
-pwd
-```
-
-  </div>
-  </div>
+<div style="display: flex; gap: 1rem;">
+  <DemoTerminal suggestedCommand="pwd" :rows="4" style="flex: 1;" />
+  <DemoTerminal suggestedCommand="cd /tmp" :rows="4" style="flex: 1;" />
 </div>
 
-<div style="margin-top: 1.5rem; text-align: center;">
-  <p style="font-size: 1.1rem !important; color: #ff6b6b;">← cd した結果が引き継がれているはず</p>
-</div>
+<p style="text-align: center; margin-top: 0.5rem; color: #ff6b6b; font-size: 1.1rem !important;">← cd した結果が引き継がれているはず</p>
 
 ---
 
@@ -251,24 +219,10 @@ pwd
 
 ## デモ
 
-<div style="height: 20px" />
-
-<div style="display: flex; justify-content: center; align-items: center; gap: 3rem;">
-  <div style="text-align: left;">
-    <p style="font-size: 1.2rem !important; color: #aaa;">以下のコマンドを入力してみてください</p>
-    <div style="margin-top: 1rem;">
-
-```bash
-rm -rf /
-```
-
-  </div>
-  </div>
-</div>
-
-<div style="margin-top: 1.5rem; text-align: center;">
-  <p style="font-size: 1.1rem !important; color: #ff6b6b;">← 今度は弾かれるはず</p>
-</div>
+<DemoTerminal
+  suggestedCommand="rm -rf /"
+  caption="← 今度は弾かれるはず"
+/>
 
 ---
 

--- a/slidev/my-strongest-presentation-slides/slides.md
+++ b/slidev/my-strongest-presentation-slides/slides.md
@@ -197,8 +197,6 @@ R --> B : レスポンス
   <DemoTerminal suggestedCommand="cd /tmp" style="flex: 1;" />
 </div>
 
-<p style="text-align: center; margin-top: 0.5rem; color: #ff6b6b; font-size: 1.1rem !important;">← cd した結果が引き継がれているはず</p>
-
 ---
 
 ## Runner: Persistent bash
@@ -216,10 +214,7 @@ R --> B : レスポンス
 
 ## デモ
 
-<DemoTerminal
-  suggestedCommand="rm -rf /"
-  caption="← 今度は弾かれるはず"
-/>
+<DemoTerminal suggestedCommand="rm -rf /" />
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace 3 static demo code blocks with `<DemoTerminal>` components
- Demo 1: single terminal with `echo "hello from $(hostname)"`
- Demo 2: two terminals side-by-side (`pwd` left, `cd /tmp` right)
- Demo 3: single terminal with `rm -rf /` (should be rejected by validation)

## Stack
1/3: #315 xterm.js + session/execute infrastructure
2/3: #317 Monaco + DemoTerminal integration
3/3: **This PR** → slides.md demo replacement

## Test plan
- [ ] All 3 demo slides render DemoTerminal components
- [ ] Demo 2 shows two terminals horizontally
- [ ] Commands execute and stream output correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)