### PR TITLE
fix: WebSocket sync regression

### DIFF
--- a/slidev/my-strongest-presentation-slides/setup/main.ts
+++ b/slidev/my-strongest-presentation-slides/setup/main.ts
@@ -19,12 +19,6 @@ const connectWebSocket = (onUpdate: (data: Partial<object>) => void): void => {
 		reconnectTimer = null;
 	}
 
-	const current = getWsInstance();
-	if (current && current.readyState !== WebSocket.CLOSED) {
-		current.onclose = null;
-		current.close();
-	}
-
 	const ws = new WebSocket(SYNC_SERVER);
 	setWsInstance(ws);
 
@@ -44,10 +38,6 @@ const connectWebSocket = (onUpdate: (data: Partial<object>) => void): void => {
 	};
 
 	ws.onclose = () => {
-		if (getWsInstance() !== ws) {
-			return;
-		}
-
 		if (connectionStatus.value === ConnectionStatusEnum.Disconnected) {
 			return;
 		}


### PR DESCRIPTION
## Summary
- Slidevの`init()`が2チャネル分（shared/drawings）で2回呼ばれるため、`connectWebSocket`も2回実行される
- 追加した「既存WSをclose」するロジックが、1回目のCONNECTING中のWSを2回目の呼び出しで閉じてしまい、同期が完全に壊れていた
- 該当ロジックを削除し、動作実績のある他デッキと同じ実装に戻す

## Test plan
- [ ] slide.ogadra.com/my-strongest-presentation-slides でWSが接続されメッセージが送受信されることを確認
- [ ] LiveIconの同期オフ/オン切替が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * WebSocket接続のハンドリングロジックを簡潔に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->