### PR TITLE
wrangler deploy が出す警告を消す

### DIFF
--- a/home/app/components/Section.tsx
+++ b/home/app/components/Section.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 /** @jsxImportSource hono/jsx */
 
 type SlideProps = {

--- a/home/app/index.tsx
+++ b/home/app/index.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 /** @jsxImportSource hono/jsx */
 
 import type { Context } from "hono";

--- a/home/demo/app.tsx
+++ b/home/demo/app.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 /** @jsxImportSource hono/jsx */
 
 import type { Context } from "hono";

--- a/home/utils/login.tsx
+++ b/home/utils/login.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 /** @jsxImportSource hono/jsx */
 
 import { compare } from "bcrypt-ts";

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sync:local": "node scripts/syncAssets.ts local",
     "dev": "pnpm run sync:local && wrangler dev --ip 0.0.0.0 --env dev",
     "start": "pnpm run sync:local && wrangler dev --ip 0.0.0.0 --env dev",
-    "deploy:prd": "pnpm run build && pnpm run sync:prd && wrangler deploy",
+    "deploy:prd": "pnpm run build && pnpm run sync:prd && wrangler deploy --env=\"\"",
     "deploy:dev": "pnpm run build && pnpm run sync:dev && wrangler deploy --env dev"
   },
   "private": true,


### PR DESCRIPTION
`pnpm run deploy:prd` の出力に警告が5件出ていたので消します。

## 環境の指定

```
▲ [WARNING] Multiple environments are defined in the Wrangler configuration file,
  but no target environment was specified for the deploy command.
```

`wrangler.jsonc` に `env.dev` があるため、`--env` なしの `wrangler deploy` はどちらを指しているのか曖昧だとwranglerが警告します。トップレベル（本番）を指すつもりなので、明示的に空文字を渡します。

```
wrangler deploy --env=""
```

## @jsx プラグマ

```
▲ [WARNING] The JSX factory cannot be set when using React's "automatic" JSX transform
    home/app/index.tsx:1:9:
      1 │ /** @jsx jsx */
```

`home/tsconfig.json` が `"jsx": "react-jsx"` と `"jsxImportSource": "hono/jsx"` を指定しているので、変換はautomaticランタイムで行われます。classic変換用の `/** @jsx jsx */` は無視されるだけで、ファイルごとに警告が出ます。`/** @jsxImportSource hono/jsx */` のほうは効いているので残します。

4ファイルとも `jsx` を識別子として参照していないことを確認しました。

## 確認したこと

`wrangler deploy --dry-run --env=""` の警告が5件から**0件**になりました。バンドルは従来どおり生成され、バインディングも `env.ASSETS (slide-decks)` のままです。

`pnpm run build` → `pnpm run sync:local` → `wrangler dev` で、変更した4ファイルを通る経路を確認しました。

| | |
|---|---|
| `/`（index.tsx + Section.tsx） | 200、slide-container が描画される |
| `/login`（login.tsx） | 200 |
| `/demo/ios-safari-app-experience`（demo/app.tsx） | 200 |
| デッキ | 200 |

typecheckは通ります。lintは `durableObjects/sandbox/handler.ts` のimport順で1件落ちますが、変更前から出ているもので今回の変更とは無関係です（stashして確認済み）。変更した4ファイル自体はbiomeを通ります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - JSX設定を更新し、アプリケーションの表示や動作を維持したまま、より新しい変換方式に対応しました。
- **デプロイ**
  - 本番デプロイ時の対象環境を明示するようになり、デプロイ設定の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->