### PR TITLE
create-slide.sh を引数なしの対話にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,9 @@ Each slide deck is self-contained with:
 ## Development Notes
 
 ### Adding New Slides
-`./create-slide.sh <slide-name-en> <slide-name-ja>` does all of this. It asks for
-the presentation date, the event name and the event page URL, and writes them into
-the headmatter along with everything else a deck needs.
+`./create-slide.sh <slide-name-en>` does all of this. It asks for the title, the
+presentation date, the event name and the event page URL, and writes them into the
+headmatter along with everything else a deck needs.
 
 By hand:
 1. Create new directory in `slidev/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,11 @@ Each slide deck is self-contained with:
 ## Development Notes
 
 ### Adding New Slides
-`./create-slide.sh <slide-name-en>` does all of this. It asks for the title, the
-presentation date, the event name and the event page URL, and writes them into the
-headmatter along with everything else a deck needs.
+`./create-slide.sh` does all of this. It takes no arguments and asks for the title,
+the English name, the presentation date, the event name and the event page URL, then
+writes them into the headmatter along with everything else a deck needs. The English
+name is the directory under `slidev/` and the URL, so it is asked again while it is
+not kebab-case or already taken.
 
 By hand:
 1. Create new directory in `slidev/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,11 @@ Each slide deck is self-contained with:
 ## Development Notes
 
 ### Adding New Slides
-`./create-slide.sh` does all of this. It takes no arguments and asks for the title,
-the English name, the presentation date, the event name and the event page URL, then
-writes them into the headmatter along with everything else a deck needs. The English
-name is the directory under `slidev/` and the URL, so it is asked again while it is
-not kebab-case or already taken.
+`./create-slide.sh` does all of this. It takes no arguments and asks for the
+Japanese name, the English name, the presentation date, the event name and the event
+page URL, then writes them into the headmatter along with everything else a deck
+needs. The English name is the directory under `slidev/`, the URL and the package
+name, so it is asked again while it is not kebab-case or already taken.
 
 By hand:
 1. Create new directory in `slidev/`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## スライド作成
 
 ```bash
-./create-slide.sh <英語名> <日本語名>
+./create-slide.sh <英語名>
 ```
 
 ## プロジェクト構造

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## スライド作成
 
 ```bash
-./create-slide.sh <英語名>
+./create-slide.sh
 ```
 
 ## プロジェクト構造

--- a/create-slide.sh
+++ b/create-slide.sh
@@ -8,9 +8,9 @@ NC='\033[0m' # No Color
 
 # Usage function
 usage() {
-    echo "Usage: $0 <slide-name-en> <slide-name-ja>"
+    echo "Usage: $0 <slide-name-en>"
     echo "Creates a new Slidev presentation with the given name"
-    echo "Example: $0 my-awesome-presentation 私の素晴らしいプレゼンテーション"
+    echo "Example: $0 my-awesome-presentation"
     exit 1
 }
 
@@ -21,7 +21,6 @@ if [ $# -eq 0 ]; then
 fi
 
 SLIDE_NAME_EN=$1
-SLIDE_NAME_JA=$2
 
 # Validate slide name (kebab-case)
 if ! [[ "$SLIDE_NAME_EN" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
@@ -56,6 +55,10 @@ ask() {
 yaml_quote() {
     printf "'%s'" "${1//\'/\'\'}"
 }
+
+ask "タイトル: " '.'
+SLIDE_TITLE=$REPLY_VALUE
+SLIDE_TITLE_YAML=$(yaml_quote "$SLIDE_TITLE")
 
 ask "発表日 (YYYY/MM/DD): " '^[0-9]{4}/[0-9]{2}/[0-9]{2}$'
 SLIDE_DATE=$(yaml_quote "$REPLY_VALUE")
@@ -98,10 +101,10 @@ EOF
 cat > "$SLIDE_DIR/slides.md" <<EOF
 ---
 theme: purplin
-title: $SLIDE_NAME_JA
+title: $SLIDE_TITLE_YAML
 date: $SLIDE_DATE
 event: $SLIDE_EVENT$SLIDE_EVENT_LINK
-info: $SLIDE_NAME_JA
+info: $SLIDE_TITLE_YAML
 colorSchema: 'dark'
 drawings:
   enabled: false
@@ -112,7 +115,7 @@ canvasWidth: 960
 
 <div style="height: 100px"/>
 
-# $SLIDE_NAME_JA
+# $SLIDE_TITLE
 
 <div style="height: 30px" />
 
@@ -164,7 +167,7 @@ div {
 <template>
   <div class="fixed left-0 bottom-0 bg-barBottom flex absolute w-full text-sm">
     <div class="text-left bg-barBottomLeft left-0 py-0.5 px-1">
-      $SLIDE_NAME_JA
+      $SLIDE_TITLE
     </div>
     <div class="w-1/2 flex justify-end ml-auto px-2">
       <Item text="ogadra">

--- a/create-slide.sh
+++ b/create-slide.sh
@@ -1,42 +1,11 @@
 #!/usr/bin/env bash
 
 # Color codes for output
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Usage function
-usage() {
-    echo "Usage: $0 <slide-name-en>"
-    echo "Creates a new Slidev presentation with the given name"
-    echo "Example: $0 my-awesome-presentation"
-    exit 1
-}
-
-# Check if slide name is provided
-if [ $# -eq 0 ]; then
-    echo -e "${RED}Error: No slide name provided${NC}"
-    usage
-fi
-
-SLIDE_NAME_EN=$1
-
-# Validate slide name (kebab-case)
-if ! [[ "$SLIDE_NAME_EN" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-    echo -e "${RED}Error: Slide name must be in kebab-case (lowercase letters, numbers, and hyphens only)${NC}"
-    echo -e "${YELLOW}Example: my-awesome-presentation${NC}"
-    exit 1
-fi
-
-# Check if directory already exists
-SLIDE_DIR="slidev/$SLIDE_NAME_EN"
-if [ -d "$SLIDE_DIR" ]; then
-    echo -e "${RED}Error: Directory $SLIDE_DIR already exists${NC}"
-    exit 1
-fi
-
-# A deck whose headmatter is missing these cannot be built.
+# Keep asking until the answer is one the deck can be built with.
 ask() {
     local prompt=$1
     local pattern=$2
@@ -59,6 +28,17 @@ yaml_quote() {
 ask "タイトル: " '.'
 SLIDE_TITLE=$REPLY_VALUE
 SLIDE_TITLE_YAML=$(yaml_quote "$SLIDE_TITLE")
+
+# The English name becomes the directory, the URL and the package name.
+while true; do
+    ask "英語名 (kebab-case): " '^[a-z0-9]+(-[a-z0-9]+)*$'
+    SLIDE_NAME_EN=$REPLY_VALUE
+    SLIDE_DIR="slidev/$SLIDE_NAME_EN"
+    if [ ! -d "$SLIDE_DIR" ]; then
+        break
+    fi
+    echo -e "${YELLOW}$SLIDE_DIR はすでにあります${NC}"
+done
 
 ask "発表日 (YYYY/MM/DD): " '^[0-9]{4}/[0-9]{2}/[0-9]{2}$'
 SLIDE_DATE=$(yaml_quote "$REPLY_VALUE")

--- a/create-slide.sh
+++ b/create-slide.sh
@@ -27,7 +27,6 @@ yaml_quote() {
 
 ask "タイトル: " '.'
 SLIDE_TITLE=$REPLY_VALUE
-SLIDE_TITLE_YAML=$(yaml_quote "$SLIDE_TITLE")
 
 # The English name becomes the directory, the URL and the package name.
 while true; do
@@ -41,10 +40,10 @@ while true; do
 done
 
 ask "発表日 (YYYY/MM/DD): " '^[0-9]{4}/[0-9]{2}/[0-9]{2}$'
-SLIDE_DATE=$(yaml_quote "$REPLY_VALUE")
+SLIDE_DATE=$REPLY_VALUE
 
 ask "イベント名: " '.'
-SLIDE_EVENT=$(yaml_quote "$REPLY_VALUE")
+SLIDE_EVENT=$REPLY_VALUE
 
 ask "イベントページのURL（任意）: " '^(https?://.+)?$'
 SLIDE_EVENT_LINK=""
@@ -81,10 +80,10 @@ EOF
 cat > "$SLIDE_DIR/slides.md" <<EOF
 ---
 theme: purplin
-title: $SLIDE_TITLE_YAML
-date: $SLIDE_DATE
-event: $SLIDE_EVENT$SLIDE_EVENT_LINK
-info: $SLIDE_TITLE_YAML
+title: $(yaml_quote "$SLIDE_TITLE")
+date: $(yaml_quote "$SLIDE_DATE")
+event: $(yaml_quote "$SLIDE_EVENT")$SLIDE_EVENT_LINK
+info: $(yaml_quote "$SLIDE_TITLE")
 colorSchema: 'dark'
 drawings:
   enabled: false

--- a/create-slide.sh
+++ b/create-slide.sh
@@ -25,10 +25,10 @@ yaml_quote() {
     printf "'%s'" "${1//\'/\'\'}"
 }
 
-ask "タイトル: " '.'
-SLIDE_TITLE=$REPLY_VALUE
+ask "日本語名: " '.'
+SLIDE_NAME_JA=$REPLY_VALUE
 
-# The English name becomes the directory, the URL and the package name.
+# The English name is the directory, the URL and the package name.
 while true; do
     ask "英語名 (kebab-case): " '^[a-z0-9]+(-[a-z0-9]+)*$'
     SLIDE_NAME_EN=$REPLY_VALUE
@@ -80,10 +80,10 @@ EOF
 cat > "$SLIDE_DIR/slides.md" <<EOF
 ---
 theme: purplin
-title: $(yaml_quote "$SLIDE_TITLE")
+title: $(yaml_quote "$SLIDE_NAME_JA")
 date: $(yaml_quote "$SLIDE_DATE")
 event: $(yaml_quote "$SLIDE_EVENT")$SLIDE_EVENT_LINK
-info: $(yaml_quote "$SLIDE_TITLE")
+info: $(yaml_quote "$SLIDE_NAME_JA")
 colorSchema: 'dark'
 drawings:
   enabled: false
@@ -94,7 +94,7 @@ canvasWidth: 960
 
 <div style="height: 100px"/>
 
-# $SLIDE_TITLE
+# $SLIDE_NAME_JA
 
 <div style="height: 30px" />
 
@@ -146,7 +146,7 @@ div {
 <template>
   <div class="fixed left-0 bottom-0 bg-barBottom flex absolute w-full text-sm">
     <div class="text-left bg-barBottomLeft left-0 py-0.5 px-1">
-      $SLIDE_TITLE
+      $SLIDE_NAME_JA
     </div>
     <div class="w-1/2 flex justify-end ml-auto px-2">
       <Item text="ogadra">


### PR DESCRIPTION
## 何を直したか

`create-slide.sh` は発表日・イベント名・イベントページURLを対話で聞くのに、日本語名と英語名だけ引数だった。シェルの引数なので `実録!コストとアクセスログ結果発表!` のような `!` を含む日本語名は履歴展開で書き換わるし、クォートも自前で気にする必要がある。聞く項目が2箇所に分かれている理由もない。

全部対話で聞くようにして、引数はなくした。日本語名が先、英語名が次。

```
$ ./create-slide.sh
日本語名: 実録!コストとアクセスログ結果発表!
英語名 (kebab-case): show-me-the-receipts
発表日 (YYYY/MM/DD): 2026/09/01
イベント名: 埼京.dev #3【俺の考えた最強の◯◯】
イベントページのURL（任意）:
```

引数を検証して `exit 1` していた3つのブロック（引数なし・kebab-caseでない・ディレクトリがすでにある）は消して、他の項目と同じく聞き直しにした。書き始めてから最初からやり直しになることがなくなる。usage 関数と `RED` も使わなくなったので消した。

## headmatter の引用符

`title` と `info` を `yaml_quote` に通した。これまでは引用符なしで書き出していたので、半角スペースに続く `#` を含む日本語名が YAML のコメント扱いで切れる。#398 で `event` を引用符で囲んだのと同じ話で、`title` だけ残っていた。

クォートは変数に入れる時点ではなく、headmatter を書き出す場所でかけている。`SLIDE_*` は全部ユーザーが打った文字列そのものを持つ。

```yaml
title: $(yaml_quote "$SLIDE_NAME_JA")
date: $(yaml_quote "$SLIDE_DATE")
event: $(yaml_quote "$SLIDE_EVENT")$SLIDE_EVENT_LINK
info: $(yaml_quote "$SLIDE_NAME_JA")
```

`SLIDE_EVENT_LINK` だけは `eventLink: '...'` の行まるごとを持つ。値が空のときはキーごと消す必要があって、行の有無を heredoc の側で表現できないため。

`Footer.vue` とスライド本文の見出しは Vue と Markdown なので、引用符なしのまま入る。

## 確認したこと

`pnpm install` の手前まで切ったコピーを使って、実際に生成した。

- headmatter・本文の見出し・`Footer.vue` の3箇所に日本語名が入ること
- 日本語名を `実録!コスト #まとめ とアクセスログ'結果発表'!` にすると headmatter が `'実録!コスト #まとめ とアクセスログ''結果発表''!'` になり、見出しは素のまま出ること
- `#` を含むイベント名が切れないこと
- URL 未入力で `eventLink` の行ごと消えること
- 英語名が `package.json` の name と `--base` に入ること
- 日本語名が空、英語名が `Taken`、英語名が既存、のそれぞれで聞き直しになること

README と CLAUDE.md の使い方も直した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - スライド作成時に、スライド名・発表日・イベント名・イベントページURLを対話形式で入力できるようになりました。
  - 入力内容がスライドのメタデータへ自動反映されます。
- **改善**
  - 英語名はkebab-case形式で検証され、既存の名前がある場合は再入力を求めるようになりました。
  - 特殊文字を含む入力も適切に処理されます。
- **ドキュメント**
  - スライド作成コマンドの使用例と手順を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->